### PR TITLE
Improve HTLC commands

### DIFF
--- a/uptick/htlc.py
+++ b/uptick/htlc.py
@@ -15,25 +15,90 @@ def htlc():
 @click.argument("amount")
 @click.argument("symbol")
 @click.option(
-    "--secret", prompt="Redeem Password", hide_input=True, confirmation_prompt=True
+    "--type", type=click.Choice(["ripemd160", "sha1", "sha256", "hash160"]),
+    default="sha256", prompt="Hash algorithm", show_default=True,
+    help="Hash algorithm"
 )
 @click.option(
-    "--hash", type=click.Choice(["ripemd160", "sha1", "sha256"]), default="ripemd160"
+    "--hash", prompt="Hash (hex string)", hide_input=False, confirmation_prompt=True,
+    help="Hash value as string of hex digits"
+)
+@click.option(
+    "--expiration", default=60 * 60, prompt="Expiration (seconds)",
+    help="Duration of HTLC in seconds"
+)
+@click.option(
+    "--length", help="Length of PREIMAGE (not of hash). Generally OK " +
+    "to leave this as 0 for unconstrained.", default=0, show_default=True
 )
 @click.option("--account")
-@click.option("--expiration", default=60 * 60)
 @click.pass_context
 @online
 @unlock
-def create(ctx, to, amount, symbol, secret, hash, account, expiration):
-    """ Create an HTLC contract
+def create(ctx, to, amount, symbol, type, hash, expiration, length, account):
+    """ Create an HTLC contract from a hash and lock-time
     """
     ctx.blockchain.blocking = True
     tx = ctx.blockchain.htlc_create(
         Amount(amount, symbol),
         to,
-        secret,
-        hash_type=hash,
+        hash_type=type,
+        hash_hex=hash,
+        expiration=expiration,
+        account=account,
+        preimage_length=length
+    )
+    tx.pop("trx", None)
+    print_tx(tx)
+    results = tx.get("operation_results", {})
+    if results:
+        htlc_id = results[0][1]
+        print("Your htlc_id is: {}".format(htlc_id))
+
+
+@htlc.command()
+@click.argument("to")
+@click.argument("amount")
+@click.argument("symbol")
+@click.option(
+    "--type", type=click.Choice(["ripemd160", "sha1", "sha256", "hash160"]),
+    default="sha256", prompt="Hash algorithm", show_default=True,
+    help="Hash algorithm"
+)
+@click.option(
+    "--secret", prompt="Redeem Password", hide_input=True, confirmation_prompt=True,
+    help="Ascii-text preimage"
+)
+@click.option("--expiration", default=60 * 60, prompt="Expiration (seconds)",
+    help="Duration of HTLC in seconds"
+)
+@click.option(
+    "--length", help="Length of PREIMAGE (not of hash). Generally OK " +
+    "to leave this as 0 for unrestricted. If non-zero, must match length " +
+    "of provided preimage", default=0, show_default=True
+)
+@click.option("--account")
+@click.pass_context
+@online
+@unlock
+def create_from_secret(ctx, to, amount, symbol, type, secret, expiration,
+                       length, account):
+    """Create an HTLC contract from a secret preimage
+
+    If you are the party choosing the preimage, this version of
+    htlc_create will compute the hash for you from the supplied
+    preimage, and create the HTLC with the resulting hash.
+    """
+    if length != 0 and length != len(secret):
+        raise ValueError("Length must be zero or agree with actual preimage length")
+
+    ctx.blockchain.blocking = True
+    tx = ctx.blockchain.htlc_create(
+        Amount(amount, symbol),
+        to,
+        preimage=secret,
+        preimage_length=length,
+        hash_type=type,
         expiration=expiration,
         account=account,
     )
@@ -47,14 +112,21 @@ def create(ctx, to, amount, symbol, secret, hash, account, expiration):
 
 @htlc.command()
 @click.argument("htlc_id")
-@click.option("--account")
 @click.option(
-    "--secret", prompt="Redeem Password", hide_input=True, confirmation_prompt=False
+    "--secret", prompt="Redeem Password", hide_input=False, confirmation_prompt=False,
+    type=str, help="The preimage, as ascii-text, unless --hex is passed"
 )
+@click.option(
+    "--hex", is_flag=True, help="Interpret preimage as hex-encoded bytes"
+)
+@click.option("--account")
 @click.pass_context
 @online
 @unlock
-def redeem(ctx, htlc_id, secret, account):
-    """ Redeem an HTLC contract
+def redeem(ctx, htlc_id, secret, hex, account):
+    """ Redeem an HTLC contract by providing preimage
     """
-    print_tx(ctx.blockchain.htlc_redeem(htlc_id, secret, account=account))
+    encoding = "hex" if hex else "utf-8"
+    print_tx(ctx.blockchain.htlc_redeem(htlc_id, secret, encoding=encoding,
+                                        account=account)
+    )


### PR DESCRIPTION
This PR breaks out the added functionality in [python-bitshares/pull/293](https://github.com/bitshares/python-bitshares/pull/293), specifically the ability to construct the HTLC from the hash, instead of the preimage.  It also updates the options, prompts, and help messages for overall clarity and to correspond with changes to HTLC in core 4.0.0, such as the addition of the Hash160 algorithm, the ability to NOT set a preimage length, etc.

Specific changes are to the `htlc create` and `htlc redeem` command.  `htlc create` was renamed to `htlc create-from-secret`, and retains the ability to create the htlc by providing the preimage, and a new `htlc create` command was added to create HTLC's from hash value alone, as would normally be expected.  The `htlc redeem` command adds a flag to indicate whether the provided preimage is hex-encoded instead of ascii.

These changes depend on changes in the underlying libraries: [python-bitshares/pull/293](https://github.com/bitshares/python-bitshares/pull/293), and  [python-graphenelib/pull/176](https://github.com/xeroc/python-graphenelib/pull/176).