### PR TITLE
Support alpha-numeric asset symbols in info command.

### DIFF
--- a/uptick/info.py
+++ b/uptick/info.py
@@ -100,7 +100,7 @@ def process_object(ctx, obj):
     elif re.match(r"^\d*\.\d*\.\d*$", obj):
         # Object Id
         objectid(ctx, obj)
-    elif obj.upper() == obj and re.match(r"^[A-Z\.]*$", obj):
+    elif obj.upper() == obj and re.match(r"^[A-Z][A-Z0-9\.]{2,15}$", obj):
         # Asset
         asset(ctx, obj)
     elif re.match("^BTS.{48,55}$", obj):


### PR DESCRIPTION
Info command incorrectly assumes that asset symbols cannot have numeric digits.  This updates the RegEx to match any uppercase alphanumeric (plus dot) sequence between 3 and 16 chars with leading alpha character and interprets it as an ASSET.